### PR TITLE
Use pseudo-inverse computation

### DIFF
--- a/esa/Dockerfile
+++ b/esa/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/*
 
 # Add application
-RUN pip install --no-cache-dir "sardem~=0.11" "scalene~=1.5.38"
+RUN pip install --no-cache-dir "sardem~=0.11" "scalene~=1.5.38" "numpy~=1.26"
 
 COPY ./esa/build/entrypoint.sh /opt
 COPY ./get_dem.py /opt/get-dem/get_dem.py

--- a/get_dem.py
+++ b/get_dem.py
@@ -120,7 +120,7 @@ def do_computations(dem: np.ndarray) -> None:
     square_dem = dem[:min_edge, :min_edge]
 
     # Multi-core section
-    np.dot(np.linalg.inv(square_dem), square_dem)
+    np.dot(np.linalg.pinv(square_dem), square_dem)
 
 
 def parse_args() -> Args:


### PR DESCRIPTION
Use `numpy.linalg.pinv` instead of `numpy.linalg.inv` to avoid "singular matrix" errors.

Upgrade `numpy` in `Dockerfile` to avoid "hanging" during computation of pseudo-inverse.

Fixes #7